### PR TITLE
Add filtering support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ observed and relayed to subscribers.
 ##### `filter(predicate)`
 Returns a *new* publisher which will only emit events that fulfill the provided
 predicate. This can be useful for branching events based on metadata such as tags.
+- `predicate` A function that accepts a log event data object as its only
+argument and returns true or false.
 
 ##### `clear()`
 Removes all emitters from observation by the Publisher.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Removes the provided emitter from observation by the Publisher.
 EventEmitter is assigned.) This is the object whose `log` events will be
 observed and relayed to subscribers.
 
+##### `filter(predicate)`
+Returns a *new* publisher which will only emit events that fulfill the provided
+predicate. This can be useful for branching events based on metadata such as tags.
+
 ##### `clear()`
 Removes all emitters from observation by the Publisher.
 

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -36,7 +36,7 @@ export default class Publisher extends EventEmitter {
     }
 
     filter(predicate) {
-        return new Publisher(predicate);
+        return new Publisher(predicate).observe(this);
     }
 
 

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -2,9 +2,10 @@ import { EventEmitter } from 'events';
 
 
 export default class Publisher extends EventEmitter {
-    constructor() {
+    constructor(predicate = () => true) {
         EventEmitter.call(this);
         this.emitters = new WeakMap();
+        this.predicate = predicate;
     }
 
     observe({ publisher = arguments[0] }) {
@@ -12,7 +13,9 @@ export default class Publisher extends EventEmitter {
         // Otherwise assume the provided argument is the emitter itself.
         if (!(publisher === this) && !this.emitters.has(publisher)) {
             let handler = (...args) => {
-                this.emit('log', ...args);
+                if (this.predicate(...args)) {
+                    this.emit('log', ...args);
+                }
             };
 
             this.emitters.set(publisher, handler);
@@ -31,6 +34,11 @@ export default class Publisher extends EventEmitter {
         }
         return this;
     }
+
+    filter(predicate) {
+        return new Publisher(predicate);
+    }
+
 
     clear() {
         this.emitters = new WeakMap();

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -36,7 +36,10 @@ export default class Publisher extends EventEmitter {
     }
 
     filter(predicate) {
-        return new Publisher(predicate).observe(this);
+        if (typeof predicate === 'function') {
+            return new Publisher(predicate).observe(this);
+        }
+        return this;
     }
 
 

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -75,24 +75,25 @@ test('Dbrickashaw', function (t) {
 
     t.test('filter', t => {
         let name = 'filter';
-
         let publisher = Dbrickashaw.getPublisher();
-        let filtered = publisher.filter(function (event) {
-            return event.error;
+        let filtered = publisher.filter(function ({ tags }) {
+            return tags.error;
         });
+
+        t.plan(10);
 
         let event = 0;
         publisher.on('log', ({ source, ts, tags, data }) => {
             event += 1;
-
-            t.equal(source, name);
-
+            
             if (event === 1) {
+                t.equal(source, name);
                 t.ok(tags.info);
                 t.equal(data, 'foo');
                 return;
             }
 
+            t.equal(source, name);
             t.ok(tags.error);
             t.equal(data, 'bar');
         });
@@ -109,5 +110,5 @@ test('Dbrickashaw', function (t) {
         logger.error(null, 'bar');
         t.end();
     });
-    
+
 });

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -85,7 +85,7 @@ test('Dbrickashaw', function (t) {
         let event = 0;
         publisher.on('log', ({ source, ts, tags, data }) => {
             event += 1;
-            
+
             if (event === 1) {
                 t.equal(source, name);
                 t.ok(tags.info);

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -71,4 +71,43 @@ test('Dbrickashaw', function (t) {
 
         logger.error(['foo', 'length', 'indexOf'], 'bar');
     });
+
+
+    t.test('filter', t => {
+        let name = 'filter';
+
+        let publisher = Dbrickashaw.getPublisher();
+        let filtered = publisher.filter(function (event) {
+            return event.error;
+        });
+
+        let event = 0;
+        publisher.on('log', ({ source, ts, tags, data }) => {
+            event += 1;
+
+            t.equal(source, name);
+
+            if (event === 1) {
+                t.ok(tags.info);
+                t.equal(data, 'foo');
+                return;
+            }
+
+            t.ok(tags.error);
+            t.equal(data, 'bar');
+        });
+
+        filtered.on('log', ({ source, ts, tags, data }) => {
+            t.equal(source, name);
+            t.notOk(tags.info);
+            t.ok(tags.error);
+            t.equal(data, 'bar');
+        });
+
+        let logger = Dbrickashaw.createLogger(name);
+        logger.info(null, 'foo');
+        logger.error(null, 'bar');
+        t.end();
+    });
+    
 });

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -76,9 +76,7 @@ test('Dbrickashaw', function (t) {
     t.test('filter', t => {
         let name = 'filter';
         let publisher = Dbrickashaw.getPublisher();
-        let filtered = publisher.filter(function ({ tags }) {
-            return tags.error;
-        });
+        let filtered = publisher.filter(({ tags }) => tags.error);
 
         t.plan(10);
 


### PR DESCRIPTION
This experimental feature allows consumers to "fork" a publisher and only observe events that fulfill a given predicate function. Calling filter will return a *new* predicate that only emits event which fulfill the provided predicate.