### PR TITLE
Experimental module instrumentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+
+node_js:
+  - "0.12"
+  - "0.10"
+  - "iojs"
+  - "iojs-v1.1.0"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ export const publisher = Dbrickashaw.getPublisher().observe(producer);
 
 # API
 
+##### `Dbrickashaw.decorate(module)`
+Decorate the current module with the `publisher` property such that it can be
+observed by dependents.
+- `module` (Object) - The `module` pseudo-global variable. It should be the
+module object for the "main" file and/or the API that is exported by the npm
+module. Otherwise, it can be any object that has a property named `exports`
+which has a mutable object for a value, e.g. `{ exports: {} }`.
+
 ## Logger
 ##### `Dbrickashaw.createLogger([name])`
 Create an instance of logger for use in a module file.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import caller from 'caller';
+import Thing from 'core-util-is';
 import Publisher from './lib/publisher';
 import Logger from './lib/logger';
 
@@ -6,6 +7,22 @@ import Logger from './lib/logger';
 const PUBLISHER = new Publisher();
 
 export default {
+
+    instrument(parent) {
+        if (Thing.isPrimitive(parent.exports)) {
+            return;
+        }
+
+        // Here we use a microtask so this can be put anywhere in
+        // the file of the module being decorated and still operate
+        // on the exported object.
+        setImmediate(() => {
+            // Assign with default values such that it's non-enumerable, etc.
+            Object.defineProperty(parent.exports, 'publisher', {
+                value: this.getPublisher()
+            });
+        });
+    },
 
     getPublisher() {
         return PUBLISHER;

--- a/index.js
+++ b/index.js
@@ -4,13 +4,19 @@ import Publisher from './lib/publisher';
 import Logger from './lib/logger';
 
 
+const PROP = 'publisher';
 const PUBLISHER = new Publisher();
 
 export default {
 
-    enable(parent) {
+    decorate(parent) {
         if (Thing.isPrimitive(parent.exports)) {
+            // noop
             return;
+        }
+
+        if (parent.exports && !Thing.isUndefined(parent.exports[PROP])) {
+            throw new Error('Publisher already exported on module.');
         }
 
         // Here we use a microtask so this can be put anywhere in
@@ -18,7 +24,7 @@ export default {
         // on the exported object.
         setImmediate(() => {
             // Assign with default values such that it's non-enumerable, etc.
-            Object.defineProperty(parent.exports, 'publisher', {
+            Object.defineProperty(parent.exports, PROP, {
                 value: this.getPublisher()
             });
         });

--- a/index.js
+++ b/index.js
@@ -16,17 +16,11 @@ export default {
         }
 
         if (parent.exports && !Thing.isUndefined(parent.exports[PROP])) {
-            throw new Error('Publisher already exported on module.');
+            throw new Error('Module already exports property `publisher`.');
         }
 
-        // Here we use a microtask so this can be put anywhere in
-        // the file of the module being decorated and still operate
-        // on the exported object.
-        setImmediate(() => {
-            // Assign with default values such that it's non-enumerable, etc.
-            Object.defineProperty(parent.exports, PROP, {
-                value: this.getPublisher()
-            });
+        Object.defineProperty(parent.exports, PROP, {
+            value: this.getPublisher()
         });
     },
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,20 @@ export default {
         Object.defineProperty(parent.exports, PROP, {
             value: this.getPublisher()
         });
+
+        // Fail if someone accidentally...
+        // <code>
+        //     Dbrickashaw.decorate(module);
+        //
+        //     /* ... sometime later */
+        //
+        //     module.exports = { /* ... */ };
+        // </code>
+        setImmediate(() => {
+            if (!(PROP in parent.exports) || parent.exports[PROP] !== this.getPublisher()) {
+                throw new Error('Publisher export overwritten.');
+            }
+        });
     },
 
     getPublisher() {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const PUBLISHER = new Publisher();
 
 export default {
 
-    instrument(parent) {
+    enable(parent) {
         if (Thing.isPrimitive(parent.exports)) {
             return;
         }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "caller": "^1.0.0",
+    "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1"
   },
   "devDependencies": {

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -169,7 +169,26 @@ test('Dbrickashaw', function (t) {
         t.ok(m.exports);
         t.ok(m.exports.publisher);
         t.strictEqual(m.exports.publisher, Dbrickashaw.getPublisher());
-        t.end();
+
+        // Simulate `module.exports = {}` after `decorate` is called.
+        m.exports = {};
+
+        // Back up existing listeners
+        let listeners = process.listeners('uncaughtException');
+        process.removeAllListeners('uncaughtException');
+
+        process.on('uncaughtException', (err) => {
+            t.ok(err);
+            t.equal(err.message, 'Publisher export overwritten.');
+
+            // Reset listeners
+            process.removeAllListeners('uncaughtException');
+            for (let listener of listeners) {
+                process.on('uncaughtException', listener);
+            }
+
+            t.end();
+        });
     });
 
 });

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -159,4 +159,18 @@ test('Dbrickashaw', function (t) {
         t.end();
     });
 
+
+    t.test('decorate', t => {
+        let m = {
+            exports: {}
+        };
+
+        Dbrickashaw.decorate(m);
+        setImmediate(() => {
+            t.ok(m.exports);
+            t.ok(m.exports.publisher);
+            t.strictEqual(m.exports.publisher, Dbrickashaw.getPublisher());
+            t.end();
+        });
+    });
 });

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -171,4 +171,5 @@ test('Dbrickashaw', function (t) {
         t.strictEqual(m.exports.publisher, Dbrickashaw.getPublisher());
         t.end();
     });
+
 });

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -166,11 +166,9 @@ test('Dbrickashaw', function (t) {
         };
 
         Dbrickashaw.decorate(m);
-        setImmediate(() => {
-            t.ok(m.exports);
-            t.ok(m.exports.publisher);
-            t.strictEqual(m.exports.publisher, Dbrickashaw.getPublisher());
-            t.end();
-        });
+        t.ok(m.exports);
+        t.ok(m.exports.publisher);
+        t.strictEqual(m.exports.publisher, Dbrickashaw.getPublisher());
+        t.end();
     });
 });


### PR DESCRIPTION
Was thinking about making it easy for consumers to add this to their published API, so thought I'd try this on for size. Open to alternate names.

```javascript
Dbrickashaw.instrument(module);
```