### PR TITLE
add to global on observe, and remove on unobserve

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ export default {
     createLogger(name = caller()) {
         let logger = new Logger(name);
         this.getPublisher().observe(logger);
-        global.__dbrickashaw[name] = this.getPublisher().filter(({source}) => source.name === name);
         return logger;
     }
 

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -26,6 +26,11 @@ export default class Publisher extends EventEmitter {
             this.emitters.set(publisher, handler);
             publisher.on(EVENT, handler);
         }
+
+        if (publisher.source) {
+            global.__dbrickashaw[publisher.source.name] = this.filter(({source}) => source.name === publisher.source.name);
+        }
+
         return this;
     }
 
@@ -37,6 +42,11 @@ export default class Publisher extends EventEmitter {
             publisher.removeListener(EVENT, handler);
             this.emitters.delete(publisher);
         }
+
+        if (publisher.source) {
+            delete global.__dbrickashaw[publisher.source.name];
+        }
+
         return this;
     }
 

--- a/test/dbrickashaw-test.js
+++ b/test/dbrickashaw-test.js
@@ -84,7 +84,7 @@ test('Dbrickashaw', function (t) {
     });
 
     t.test('exposed publisher', t => {
-        t.plan(6);
+        t.plan(7);
 
         let name = 'test_global';
         let logger = Dbrickashaw.createLogger(name);
@@ -94,6 +94,10 @@ test('Dbrickashaw', function (t) {
         t.ok(Dbrickashaw.getPublisherAggregate().test_global);
         t.ok(global.__dbrickashaw);
         t.ok(global.__dbrickashaw.test_global);
+
+        Dbrickashaw.getPublisher().unobserve(logger);
+        
+        t.ok(!global.__dbrickashaw.test_global);
 
         reset();
         t.end();


### PR DESCRIPTION
This would allow you to also remove loggers from global publishers.

In the case of wanting to create a transient logger this becomes useful.
